### PR TITLE
added a public setOrderOptedIn function

### DIFF
--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/AirRobeWidget.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/AirRobeWidget.kt
@@ -116,6 +116,10 @@ object AirRobeWidget {
         AirRobeSharedPreferenceManager.setOptedIn(context, false)
     }
 
+    fun setOrderOptedIn(context: Context, orderOptedIn: Boolean) {
+        AirRobeSharedPreferenceManager.setOrderOptedIn(context, orderOptedIn)
+    }
+
     fun orderOptedIn(context: Context): Boolean {
         return AirRobeSharedPreferenceManager.getOrderOptedIn(context)
     }

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/AirRobeWidget.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/AirRobeWidget.kt
@@ -116,8 +116,8 @@ object AirRobeWidget {
         AirRobeSharedPreferenceManager.setOptedIn(context, false)
     }
 
-    fun setOrderOptedIn(context: Context, orderOptedIn: Boolean) {
-        AirRobeSharedPreferenceManager.setOrderOptedIn(context, orderOptedIn)
+    fun resetOrder(context: Context) {
+        AirRobeSharedPreferenceManager.setOrderOptedIn(context, false)
     }
 
     fun orderOptedIn(context: Context): Boolean {


### PR DESCRIPTION
Issue Report scenario is:
1. Customer buys a shirt and turns on AR. The OCP displays the AR widget, this is correct.
2. The next time they buy a notebook (the widget is still on for other eligible products eg shirts). The OCP  displays the AR widget, which is not correct since it’s a notebook.

So my thought on this report is there isn't an actual issue in our SDK.
But The problem is that they decide to render the `multi-opt-in` widget after they got the eligibility result of the `multi-opt-in` widget by calling an exposed function named `checkMultiOptInEligibility` . and if it returns `not-eligible`, then they rather not render `multi-opt-in` widget on their end.
which means our SDK skips the operation of updating OrderOptedIn value.
So if `OrderOptedIn` was previously set as `true` , this value won't change in the above case, and on confirmation view, the widget will be automatically eligible.
This made the issue.

So I added another function called `setOrderOptedIn` to let them set the value manually on their end just for them.