### PR TITLE
update company name from backend, remove hardcoded company name

### DIFF
--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/config/AirRobeWidgetConfig.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/config/AirRobeWidgetConfig.kt
@@ -7,13 +7,11 @@ enum class Mode {
 
 interface AirRobeWidgetConfig {
     val appId: String
-    val privacyPolicyURL: String
     val mode: Mode
 }
 
 internal class AirRobeWidgetConfigImpl (
     override val appId: String,
-    override val privacyPolicyURL: String,
     override val mode: Mode
 ) : AirRobeWidgetConfig
 
@@ -21,14 +19,11 @@ internal class AirRobeWidgetConfigImpl (
  * Create a [AirRobeWidgetConfig] instance.
  *
  * @param appId App ID from https://connector.airrobe.com
- * @param privacyPolicyURL Privacy Policy link for the Iconic
- * @param color Primary color for the widgets
  * @param mode Selector for production or sandbox mode
  */
 fun AirRobeWidgetConfig (
     appId: String,
-    privacyPolicyURL: String,
     mode: Mode = Mode.PRODUCTION
 ) : AirRobeWidgetConfig = AirRobeWidgetConfigImpl(
-    appId, privacyPolicyURL, mode
+    appId, mode
 )

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeGetShoppingDataController.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeGetShoppingDataController.kt
@@ -29,6 +29,8 @@ internal class AirRobeGetShoppingDataController {
                 query GetShoppingData {
                   shop(appId: "$appId") {
                     name
+                    privacyUrl
+                    popupFindOutMoreUrl
                     categoryMappings(mappedOrExcludedOnly: true) {
                       from
                       to
@@ -68,6 +70,8 @@ internal class AirRobeGetShoppingDataController {
             val data = jsonObject.getJSONObject("data")
             val shop = data.getJSONObject("shop")
             val companyName = shop.getString("name")
+            val privacyUrl = shop.getString("privacyUrl")
+            val popupFindOutMoreUrl = shop.getString("popupFindOutMoreUrl")
             val categoryMappings = shop.getJSONArray("categoryMappings")
             val minimumPriceThresholds = shop.getJSONArray("minimumPriceThresholds")
             val categoryMappingsArray: MutableList<AirRobeCategoryMapping> = arrayListOf()
@@ -97,7 +101,11 @@ internal class AirRobeGetShoppingDataController {
             val dataModel = AirRobeGetShoppingDataModel(
                 AirRobeShoppingDataModel(
                     AirRobeShopModel(
-                        companyName, categoryMappingsArray, minimumPriceThresholdsArray
+                        companyName,
+                        privacyUrl,
+                        popupFindOutMoreUrl,
+                        categoryMappingsArray,
+                        minimumPriceThresholdsArray
                     )
                 )
             )

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeGetShoppingDataController.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeGetShoppingDataController.kt
@@ -70,11 +70,7 @@ internal class AirRobeGetShoppingDataController {
         try {
             val data = jsonObject.getJSONObject("data")
             val shop = data.getJSONObject("shop")
-            val companyName = try {
-                shop.getString("name")
-            } catch (exception: Exception) {
-                null
-            }
+            val companyName = shop.getString("name")
             val privacyUrl = try {
                 shop.getString("privacyUrl")
             } catch (exception: Exception) {

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeGetShoppingDataController.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeGetShoppingDataController.kt
@@ -13,6 +13,7 @@ import com.airrobe.widgetsdk.airrobewidget.service.models.AirRobeMinPriceThresho
 import com.airrobe.widgetsdk.airrobewidget.service.models.AirRobeShopModel
 import org.json.JSONException
 import org.json.JSONObject
+import java.lang.Exception
 import java.util.concurrent.Executors
 
 internal class AirRobeGetShoppingDataController {
@@ -69,8 +70,16 @@ internal class AirRobeGetShoppingDataController {
         try {
             val data = jsonObject.getJSONObject("data")
             val shop = data.getJSONObject("shop")
-            val companyName = shop.getString("name")
-            val privacyUrl = shop.getString("privacyUrl")
+            val companyName = try {
+                shop.getString("name")
+            } catch (exception: Exception) {
+                null
+            }
+            val privacyUrl = try {
+                shop.getString("privacyUrl")
+            } catch (exception: Exception) {
+                null
+            }
             val popupFindOutMoreUrl = shop.getString("popupFindOutMoreUrl")
             val categoryMappings = shop.getJSONArray("categoryMappings")
             val minimumPriceThresholds = shop.getJSONArray("minimumPriceThresholds")

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeGetShoppingDataController.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeGetShoppingDataController.kt
@@ -28,6 +28,7 @@ internal class AirRobeGetShoppingDataController {
                 """
                 query GetShoppingData {
                   shop(appId: "$appId") {
+                    name
                     categoryMappings(mappedOrExcludedOnly: true) {
                       from
                       to
@@ -66,6 +67,7 @@ internal class AirRobeGetShoppingDataController {
         try {
             val data = jsonObject.getJSONObject("data")
             val shop = data.getJSONObject("shop")
+            val companyName = shop.getString("name")
             val categoryMappings = shop.getJSONArray("categoryMappings")
             val minimumPriceThresholds = shop.getJSONArray("minimumPriceThresholds")
             val categoryMappingsArray: MutableList<AirRobeCategoryMapping> = arrayListOf()
@@ -95,7 +97,7 @@ internal class AirRobeGetShoppingDataController {
             val dataModel = AirRobeGetShoppingDataModel(
                 AirRobeShoppingDataModel(
                     AirRobeShopModel(
-                        categoryMappingsArray, minimumPriceThresholdsArray
+                        companyName, categoryMappingsArray, minimumPriceThresholdsArray
                     )
                 )
             )

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeGetShoppingDataModel.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeGetShoppingDataModel.kt
@@ -57,6 +57,8 @@ internal data class AirRobeShoppingDataModel(
 
 internal data class AirRobeShopModel(
     var companyName: String,
+    var privacyUrl: String,
+    var popupFindOutMoreUrl: String,
     var categoryMappings: MutableList<AirRobeCategoryMapping>,
     var minimumPriceThresholds: MutableList<AirRobeMinPriceThresholds>
 )

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeGetShoppingDataModel.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeGetShoppingDataModel.kt
@@ -56,7 +56,7 @@ internal data class AirRobeShoppingDataModel(
 )
 
 internal data class AirRobeShopModel(
-    var companyName: String?,
+    var companyName: String,
     var privacyUrl: String?,
     var popupFindOutMoreUrl: String,
     var categoryMappings: MutableList<AirRobeCategoryMapping>,

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeGetShoppingDataModel.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeGetShoppingDataModel.kt
@@ -56,8 +56,8 @@ internal data class AirRobeShoppingDataModel(
 )
 
 internal data class AirRobeShopModel(
-    var companyName: String,
-    var privacyUrl: String,
+    var companyName: String?,
+    var privacyUrl: String?,
     var popupFindOutMoreUrl: String,
     var categoryMappings: MutableList<AirRobeCategoryMapping>,
     var minimumPriceThresholds: MutableList<AirRobeMinPriceThresholds>

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeGetShoppingDataModel.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeGetShoppingDataModel.kt
@@ -56,6 +56,7 @@ internal data class AirRobeShoppingDataModel(
 )
 
 internal data class AirRobeShopModel(
+    var companyName: String,
     var categoryMappings: MutableList<AirRobeCategoryMapping>,
     var minimumPriceThresholds: MutableList<AirRobeMinPriceThresholds>
 )

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeLearnMore.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeLearnMore.kt
@@ -107,6 +107,9 @@ internal class AirRobeLearnMore(context: Context) : Dialog(context) {
             }
         }
 
+        var findOutMoreText = context.resources.getString(R.string.airrobe_learn_more_find_more_text)
+        findOutMoreText = findOutMoreText.replace(findOutMoreText, "<a href='${widgetInstance.shopModel?.data?.shop?.popupFindOutMoreUrl}'>$findOutMoreText</a>")
+        tvFindOutMore.text = AirRobeAppUtils.fromHtml(findOutMoreText)
         tvFindOutMore.movementMethod = LinkMovementMethod.getInstance()
         initColorSet()
     }

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
@@ -18,6 +18,7 @@ import android.text.TextPaint
 
 import android.text.Spanned
 import android.view.View
+import android.webkit.URLUtil
 import android.widget.*
 import com.airrobe.widgetsdk.airrobewidget.config.EventName
 import com.airrobe.widgetsdk.airrobewidget.config.PageName
@@ -278,7 +279,7 @@ class AirRobeMultiOptIn @JvmOverloads constructor(
     }
 
     private fun setExtraInfoText() {
-        if (widgetInstance.shopModel?.data?.shop?.privacyUrl.isNullOrEmpty() || widgetInstance.shopModel?.data?.shop?.companyName.isNullOrEmpty()) {
+        if (!URLUtil.isValidUrl(widgetInstance.shopModel?.data?.shop?.privacyUrl)) {
             tvExtraInfo.visibility = GONE
         } else {
             tvExtraInfo.visibility = VISIBLE

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
@@ -279,7 +279,7 @@ class AirRobeMultiOptIn @JvmOverloads constructor(
 
     private fun setExtraInfoText() {
         var extraInfoText = context.resources.getString(R.string.airrobe_extra_info, widgetInstance.shopModel?.data?.shop?.companyName)
-        extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.configuration?.privacyPolicyURL}'>Privacy Policy</a>")
+        extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.shopModel?.data?.shop?.privacyUrl}'>Privacy Policy</a>")
         tvExtraInfo.text = AirRobeAppUtils.fromHtml(extraInfoText)
         tvExtraInfo.movementMethod = LinkMovementMethod.getInstance()
     }

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
@@ -278,7 +278,8 @@ class AirRobeMultiOptIn @JvmOverloads constructor(
     }
 
     private fun setExtraInfoText() {
-        val extraInfoText = context.resources.getString(R.string.airrobe_extra_info).replace("Privacy Policy", "<a href='${widgetInstance.configuration?.privacyPolicyURL}'>Privacy Policy</a>")
+        var extraInfoText = context.resources.getString(R.string.airrobe_extra_info, widgetInstance.shopModel?.data?.shop?.companyName)
+        extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.configuration?.privacyPolicyURL}'>Privacy Policy</a>")
         tvExtraInfo.text = AirRobeAppUtils.fromHtml(extraInfoText)
         tvExtraInfo.movementMethod = LinkMovementMethod.getInstance()
     }

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
@@ -278,10 +278,15 @@ class AirRobeMultiOptIn @JvmOverloads constructor(
     }
 
     private fun setExtraInfoText() {
-        var extraInfoText = context.resources.getString(R.string.airrobe_extra_info, widgetInstance.shopModel?.data?.shop?.companyName)
-        extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.shopModel?.data?.shop?.privacyUrl}'>Privacy Policy</a>")
-        tvExtraInfo.text = AirRobeAppUtils.fromHtml(extraInfoText)
-        tvExtraInfo.movementMethod = LinkMovementMethod.getInstance()
+        if (widgetInstance.shopModel?.data?.shop?.privacyUrl.isNullOrEmpty() || widgetInstance.shopModel?.data?.shop?.companyName.isNullOrEmpty()) {
+            tvExtraInfo.visibility = GONE
+        } else {
+            tvExtraInfo.visibility = VISIBLE
+            var extraInfoText = context.resources.getString(R.string.airrobe_extra_info, widgetInstance.shopModel?.data?.shop?.companyName)
+            extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.shopModel?.data?.shop?.privacyUrl}'>Privacy Policy</a>")
+            tvExtraInfo.text = AirRobeAppUtils.fromHtml(extraInfoText)
+            tvExtraInfo.movementMethod = LinkMovementMethod.getInstance()
+        }
     }
 
     fun initialize(

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeOptIn.kt
@@ -14,6 +14,7 @@ import android.text.style.ClickableSpan
 import android.util.AttributeSet
 import android.util.Log
 import android.view.View
+import android.webkit.URLUtil
 import android.widget.*
 import com.airrobe.widgetsdk.airrobewidget.R
 import com.airrobe.widgetsdk.airrobewidget.config.*
@@ -293,7 +294,7 @@ class AirRobeOptIn @JvmOverloads constructor(
     }
 
     private fun setExtraInfoText() {
-        if (widgetInstance.shopModel?.data?.shop?.privacyUrl.isNullOrEmpty() || widgetInstance.shopModel?.data?.shop?.companyName.isNullOrEmpty()) {
+        if (!URLUtil.isValidUrl(widgetInstance.shopModel?.data?.shop?.privacyUrl)) {
             tvExtraInfo.visibility = GONE
         } else {
             tvExtraInfo.visibility = VISIBLE

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeOptIn.kt
@@ -293,7 +293,8 @@ class AirRobeOptIn @JvmOverloads constructor(
     }
 
     private fun setExtraInfoText() {
-        val extraInfoText = context.resources.getString(R.string.airrobe_extra_info).replace("Privacy Policy", "<a href='${widgetInstance.configuration?.privacyPolicyURL}'>Privacy Policy</a>")
+        var extraInfoText = context.resources.getString(R.string.airrobe_extra_info, widgetInstance.shopModel?.data?.shop?.companyName)
+        extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.configuration?.privacyPolicyURL}'>Privacy Policy</a>")
         tvExtraInfo.text = AirRobeAppUtils.fromHtml(extraInfoText)
         tvExtraInfo.movementMethod = LinkMovementMethod.getInstance()
     }

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeOptIn.kt
@@ -294,7 +294,7 @@ class AirRobeOptIn @JvmOverloads constructor(
 
     private fun setExtraInfoText() {
         var extraInfoText = context.resources.getString(R.string.airrobe_extra_info, widgetInstance.shopModel?.data?.shop?.companyName)
-        extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.configuration?.privacyPolicyURL}'>Privacy Policy</a>")
+        extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.shopModel?.data?.shop?.privacyUrl}'>Privacy Policy</a>")
         tvExtraInfo.text = AirRobeAppUtils.fromHtml(extraInfoText)
         tvExtraInfo.movementMethod = LinkMovementMethod.getInstance()
     }

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeOptIn.kt
@@ -293,10 +293,15 @@ class AirRobeOptIn @JvmOverloads constructor(
     }
 
     private fun setExtraInfoText() {
-        var extraInfoText = context.resources.getString(R.string.airrobe_extra_info, widgetInstance.shopModel?.data?.shop?.companyName)
-        extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.shopModel?.data?.shop?.privacyUrl}'>Privacy Policy</a>")
-        tvExtraInfo.text = AirRobeAppUtils.fromHtml(extraInfoText)
-        tvExtraInfo.movementMethod = LinkMovementMethod.getInstance()
+        if (widgetInstance.shopModel?.data?.shop?.privacyUrl.isNullOrEmpty() || widgetInstance.shopModel?.data?.shop?.companyName.isNullOrEmpty()) {
+            tvExtraInfo.visibility = GONE
+        } else {
+            tvExtraInfo.visibility = VISIBLE
+            var extraInfoText = context.resources.getString(R.string.airrobe_extra_info, widgetInstance.shopModel?.data?.shop?.companyName)
+            extraInfoText = extraInfoText.replace("Privacy Policy", "<a href='${widgetInstance.shopModel?.data?.shop?.privacyUrl}'>Privacy Policy</a>")
+            tvExtraInfo.text = AirRobeAppUtils.fromHtml(extraInfoText)
+            tvExtraInfo.movementMethod = LinkMovementMethod.getInstance()
+        }
     }
 
     fun initialize(

--- a/AirRobeWidget/src/main/res/values/strings.xml
+++ b/AirRobeWidget/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="airrobe_detailed_description">We’ve partnered with AirRobe to enable you to join the circular fashion movement. Re-sell or rent your purchases on AirRobe’s marketplace – all with one simple click. Together, we can do our part to keep fashion out of landfill. Learn more.</string>
     <string name="airrobe_learn_more_link_text">Learn more.</string>
 
-    <string name="airrobe_extra_info">By opting in you agree to THE ICONIC’s Privacy Policy and consent for us to share your details with AirRobe.</string>
+    <string name="airrobe_extra_info">By opting in you agree to %1$s’s Privacy Policy and consent for us to share your details with AirRobe.</string>
 
     <string name="airrobe_learn_more_title">HOW IT WORKS</string>
     <string name="airrobe_learn_more_step1_title">1. ADD TO AIRROBE</string>

--- a/AirRobeWidget/src/main/res/values/strings.xml
+++ b/AirRobeWidget/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="airrobe_learn_more_answer">Don`t panic! You`ll be directed to set up your free account at the order confirmation page.</string>
     <string name="airrobe_learn_more_ready">READY TO GET STARTED?</string>
     <string name="airrobe_learn_more_toggle_on">TOGGLE ON!</string>
-    <string name="airrobe_learn_more_find_more_text"><a href="https://www.theiconic.com.au/airrobe/">Find out more about AirRobe.</a></string>
+    <string name="airrobe_learn_more_find_more_text">Find out more about AirRobe.</string>
 
     <string name="airrobe_order_confirmation_title">Your items are in</string>
     <string name="airrobe_order_confirmation_description">Simply activate your free account below to re-sell your items back into a circular economy after you`ve worn and loved them.</string>

--- a/AirRobeWidget/src/main/res/values/strings.xml
+++ b/AirRobeWidget/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="airrobe_widget_version">1.0.6</string>
+    <string name="airrobe_widget_version">1.0.7</string>
     <string name="airrobe_added_to">Added To</string>
     <string name="airrobe_add_to">Add To</string>
 

--- a/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/ApplicationController.kt
+++ b/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/ApplicationController.kt
@@ -15,7 +15,6 @@ class ApplicationController : Application(), AirRobeEventListener {
         AirRobeWidget.initialize(
             AirRobeWidgetConfig(
                 "515b6ee129da",
-                "https://www.example.com/privacy-policy",
                 Mode.SANDBOX
             )
         )

--- a/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/BrandActivity.kt
+++ b/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/BrandActivity.kt
@@ -1,5 +1,7 @@
 package com.airrobe.widgetsdk.airrobedemo.activities
 
+import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -8,9 +10,13 @@ import com.airrobe.widgetsdk.airrobedemo.R
 import com.airrobe.widgetsdk.airrobedemo.adapters.BrandsRVAdapter
 import com.airrobe.widgetsdk.airrobedemo.configs.Consts
 import com.airrobe.widgetsdk.airrobedemo.ui.VerticalSpaceItemDecoration
+import com.airrobe.widgetsdk.airrobedemo.utils.SharedPreferenceManager
 import com.airrobe.widgetsdk.airrobedemo.utils.StatusBarTranslucent
+import com.airrobe.widgetsdk.airrobedemo.utils.Utils
+import ru.nikartm.support.ImageBadgeView
 
 class BrandActivity : AppCompatActivity() {
+    @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_brand)
@@ -23,5 +29,21 @@ class BrandActivity : AppCompatActivity() {
 
         val rvBrandAdapter = BrandsRVAdapter(this, Consts.brands)
         rvBrand.adapter = rvBrandAdapter
+
+        val ivCart = findViewById<ImageBadgeView>(R.id.iv_cart)
+        ivCart.setOnTouchListener { view, motionEvent ->
+            if (Utils.touchAnimator(this, view, motionEvent)) {
+                val intent = Intent(this, CartActivity::class.java)
+                startActivity(intent)
+            }
+            true
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val items = SharedPreferenceManager.getCartItems(this)
+        val ivCart = findViewById<ImageBadgeView>(R.id.iv_cart)
+        ivCart.badgeValue = items.count()
     }
 }

--- a/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/CartActivity.kt
+++ b/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/CartActivity.kt
@@ -15,6 +15,7 @@ import com.airrobe.widgetsdk.airrobedemo.ui.VerticalSpaceItemDecoration
 import com.airrobe.widgetsdk.airrobedemo.utils.SharedPreferenceManager
 import com.airrobe.widgetsdk.airrobedemo.utils.StatusBarTranslucent
 import com.airrobe.widgetsdk.airrobedemo.utils.Utils
+import com.airrobe.widgetsdk.airrobedemo.utils.Utils.toast
 import com.airrobe.widgetsdk.airrobewidget.widgets.AirRobeMultiOptIn
 
 class CartActivity : AppCompatActivity() {
@@ -46,9 +47,13 @@ class CartActivity : AppCompatActivity() {
         val rlPlaceOrder = findViewById<RelativeLayout>(R.id.rl_place_order)
         rlPlaceOrder.setOnTouchListener { view, motionEvent ->
             if (Utils.touchAnimator(this, view, motionEvent)) {
-                val intent = Intent(this, ConfirmationActivity::class.java)
-                intent.putExtra("email", etEmail.text.toString())
-                startActivity(intent)
+                if (Utils.isValidEmail(etEmail.text.toString())) {
+                    val intent = Intent(this, ConfirmationActivity::class.java)
+                    intent.putExtra("email", etEmail.text.toString())
+                    startActivity(intent)
+                } else {
+                    toast("Email is invalid.")
+                }
             }
             true
         }

--- a/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/CategoryActivity.kt
+++ b/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/CategoryActivity.kt
@@ -12,8 +12,10 @@ import com.airrobe.widgetsdk.airrobedemo.R
 import com.airrobe.widgetsdk.airrobedemo.adapters.CategoriesRVAdapter
 import com.airrobe.widgetsdk.airrobedemo.configs.Consts
 import com.airrobe.widgetsdk.airrobedemo.ui.VerticalSpaceItemDecoration
+import com.airrobe.widgetsdk.airrobedemo.utils.SharedPreferenceManager
 import com.airrobe.widgetsdk.airrobedemo.utils.StatusBarTranslucent
 import com.airrobe.widgetsdk.airrobedemo.utils.Utils
+import ru.nikartm.support.ImageBadgeView
 
 class CategoryActivity : AppCompatActivity() {
     @SuppressLint("ClickableViewAccessibility")
@@ -41,5 +43,21 @@ class CategoryActivity : AppCompatActivity() {
             }
             true
         }
+
+        val ivCart = findViewById<ImageBadgeView>(R.id.iv_cart)
+        ivCart.setOnTouchListener { view, motionEvent ->
+            if (Utils.touchAnimator(this, view, motionEvent)) {
+                val intent = Intent(this, CartActivity::class.java)
+                startActivity(intent)
+            }
+            true
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val items = SharedPreferenceManager.getCartItems(this)
+        val ivCart = findViewById<ImageBadgeView>(R.id.iv_cart)
+        ivCart.badgeValue = items.count()
     }
 }

--- a/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/SubCategoryActivity.kt
+++ b/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/SubCategoryActivity.kt
@@ -1,6 +1,7 @@
 package com.airrobe.widgetsdk.airrobedemo.activities
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.widget.ImageView
 import android.widget.TextView
@@ -11,8 +12,10 @@ import com.airrobe.widgetsdk.airrobedemo.R
 import com.airrobe.widgetsdk.airrobedemo.adapters.SubCategoriesRVAdapter
 import com.airrobe.widgetsdk.airrobedemo.configs.Consts
 import com.airrobe.widgetsdk.airrobedemo.ui.VerticalSpaceItemDecoration
+import com.airrobe.widgetsdk.airrobedemo.utils.SharedPreferenceManager
 import com.airrobe.widgetsdk.airrobedemo.utils.StatusBarTranslucent
 import com.airrobe.widgetsdk.airrobedemo.utils.Utils
+import ru.nikartm.support.ImageBadgeView
 
 class SubCategoryActivity : AppCompatActivity() {
     @SuppressLint("ClickableViewAccessibility")
@@ -43,5 +46,21 @@ class SubCategoryActivity : AppCompatActivity() {
             }
             true
         }
+
+        val ivCart = findViewById<ImageBadgeView>(R.id.iv_cart)
+        ivCart.setOnTouchListener { view, motionEvent ->
+            if (Utils.touchAnimator(this, view, motionEvent)) {
+                val intent = Intent(this, CartActivity::class.java)
+                startActivity(intent)
+            }
+            true
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val items = SharedPreferenceManager.getCartItems(this)
+        val ivCart = findViewById<ImageBadgeView>(R.id.iv_cart)
+        ivCart.badgeValue = items.count()
     }
 }

--- a/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/utils/Utils.kt
+++ b/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/utils/Utils.kt
@@ -1,12 +1,21 @@
 package com.airrobe.widgetsdk.airrobedemo.utils
 
 import android.content.Context
+import android.text.TextUtils
+import android.util.Patterns
 import android.view.MotionEvent
 import android.view.View
 import android.view.animation.AnimationUtils
+import android.widget.Toast
 import com.airrobe.widgetsdk.airrobedemo.R
 
 object Utils {
+    fun isValidEmail(email: CharSequence): Boolean {
+        return !TextUtils.isEmpty(email) && Patterns.EMAIL_ADDRESS.matcher(email).matches()
+    }
+
+    fun Context.toast(message: CharSequence) = Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+
     fun touchAnimator(context: Context, v: View, event: MotionEvent): Boolean {
         when (event.action) {
             MotionEvent.ACTION_DOWN -> {

--- a/demo/src/main/res/layout/activity_brand.xml
+++ b/demo/src/main/res/layout/activity_brand.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -23,6 +24,16 @@
                 android:textColor="@color/black"
                 android:textSize="20sp"
                 android:textStyle="bold" />
+
+            <ru.nikartm.support.ImageBadgeView
+                android:id="@+id/iv_cart"
+                android:layout_width="35dp"
+                android:layout_height="35dp"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:src="@drawable/cart"
+                app:ibv_badgeTextSize="12sp"
+                app:ibv_fixedBadgeRadius="10dp"/>
 
         </RelativeLayout>
 

--- a/demo/src/main/res/layout/activity_category.xml
+++ b/demo/src/main/res/layout/activity_category.xml
@@ -33,6 +33,16 @@
                 android:textSize="20sp"
                 android:textStyle="bold" />
 
+            <ru.nikartm.support.ImageBadgeView
+                android:id="@+id/iv_cart"
+                android:layout_width="35dp"
+                android:layout_height="35dp"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:src="@drawable/cart"
+                app:ibv_badgeTextSize="12sp"
+                app:ibv_fixedBadgeRadius="10dp"/>
+
         </RelativeLayout>
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/demo/src/main/res/layout/activity_sub_category.xml
+++ b/demo/src/main/res/layout/activity_sub_category.xml
@@ -33,6 +33,16 @@
                 android:textSize="20sp"
                 android:textStyle="bold" />
 
+            <ru.nikartm.support.ImageBadgeView
+                android:id="@+id/iv_cart"
+                android:layout_width="35dp"
+                android:layout_height="35dp"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:src="@drawable/cart"
+                app:ibv_badgeTextSize="12sp"
+                app:ibv_fixedBadgeRadius="10dp"/>
+
         </RelativeLayout>
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ SONATYPE_HOST=S01
 RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.airrobe
-VERSION_NAME=1.0.6
+VERSION_NAME=1.0.7
 
 POM_URL=https://github.com/airrobe/widget-sdk-android/
 POM_SCM_URL=https://github.com/airrobe/widget-sdk-android/


### PR DESCRIPTION
### Test plans

 **How it works**
We are currently getting company name, privacy url, find out more url, category mapping data etc. from `connector/graphql` with below query.
```
query GetShoppingData ($appId: String) {
  shop(appId: $appId) {
    name
    privacyUrl
    popupFindOutMoreUrl
    categoryMappings(mappedOrExcludedOnly: true) {
      from
      to
      excluded
    }
    minimumPriceThresholds {
      default
      department
      minimumPriceCents
    }
  }
}
```

if `privacyUrl` is `null`, we hide "By opting in..." text block.
if not, we use this `privacyUrl` for the privacy link in "By opting in..." text block.
Also we use `name` value for the company name in "By opting in..." text block.
And we use `popupFindOutMoreUrl` for the find out more URL in Learn More popup widget.

-- Note
`name` and `popupFindOutMoreUrl` are not nullable while `privacyUrl` is nullable.
And in order to test it successfully, `categoryMappings` should have data. but optional.

**Test Environment**
- Open our demo project through Android Studio.
- Inside `../airrobedemo/ApplicationController.kt -> ApplicationController class -> onCreate()`, we have `initialize` function which has `appId` and `mode` as params.
- Update these `appId` and `mode` and test out the below cases.

**Test Cases**
We can test this out by simulating the connector api call with a specific `app_id`.
- [x] check whether "By opting in ..." text block is hidden if the privacy URL is `null`.
- [x] check whether it's updated with company name and privacy URL as per it comes from the connector based on `app_id`.
- [x] check whether it's updated with popup find more URL as per it comes from the connector based on `app_id`.