### PR TITLE
Eli/create opted out order

### DIFF
--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/config/AirRobeConstants.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/config/AirRobeConstants.kt
@@ -3,6 +3,7 @@ package com.airrobe.widgetsdk.airrobewidget.config
 internal class AirRobeConstants {
     companion object {
         const val FLOAT_NULL_MAGIC_VALUE = 0.000003f
+        const val INT_NULL_MAGIC_VALUE = -987654321
         const val AIRROBE_CONNECTOR_SANDBOX = "https://sandbox.connector.airrobe.com"
         const val AIRROBE_CONNECTOR_PRODUCTION = "https://connector.airrobe.com"
         const val PRICE_ENGINE_HOST = "https://price-engine.airrobe.com"

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeCreateOptedOutOrderController.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeCreateOptedOutOrderController.kt
@@ -18,24 +18,38 @@ internal class AirRobeCreateOptedOutOrderController {
 
     fun start(orderId: String, appId: String, orderSubTotalCents: Int, currency: String, mode: Mode) {
         myExecutor.execute {
-            val input = JSONObject()
-            input.put("id", orderId)
-            input.put("shopAppId", appId)
-            val subTotal = JSONObject()
-            subTotal.put("cents", orderSubTotalCents)
-            subTotal.put("currency", currency)
-            input.put("subtotal", subTotal)
             val param = JSONObject()
             param.put(
                 "query",
                 """
-                mutation CreateOptedOutOrder {
-                  createOptedOutOrder(input: "$input") {
+                mutation CreateOptedOutOrder(${'$'}input: CreateOptedOutOrderMutationInput!) {
+                  createOptedOutOrder(input: ${'$'}input) {
                     created
                     error
                   }
                 }
             """
+            )
+
+            val inputData = JSONObject()
+            inputData.put("id", orderId)
+            inputData.put("shopAppId", appId)
+
+            val subTotal = JSONObject()
+            subTotal.put("cents", orderSubTotalCents)
+            subTotal.put("currency", currency)
+            inputData.put("subtotal", subTotal)
+
+            val input = JSONObject()
+            input.put("input", inputData)
+
+            param.put(
+                "variables",
+                input
+            )
+            param.put(
+                "operationName",
+                "CreateOptedOutOrder"
             )
 
             val response = AirRobeApiService.requestPOST(

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeCreateOptedOutOrderController.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeCreateOptedOutOrderController.kt
@@ -1,0 +1,78 @@
+package com.airrobe.widgetsdk.airrobewidget.service.api_controllers
+
+import android.os.Handler
+import android.os.Looper
+import com.airrobe.widgetsdk.airrobewidget.config.AirRobeConstants
+import com.airrobe.widgetsdk.airrobewidget.config.Mode
+import com.airrobe.widgetsdk.airrobewidget.service.AirRobeApiService
+import com.airrobe.widgetsdk.airrobewidget.service.listeners.AirRobeCreateOptedOutOrderListener
+import com.airrobe.widgetsdk.airrobewidget.service.models.*
+import org.json.JSONException
+import org.json.JSONObject
+import java.util.concurrent.Executors
+
+internal class AirRobeCreateOptedOutOrderController {
+    private val myExecutor = Executors.newSingleThreadExecutor()
+    private val myHandler = Handler(Looper.getMainLooper())
+    var airRobeCreateOptedOutOrderListener: AirRobeCreateOptedOutOrderListener? = null
+
+    fun start(orderId: String, appId: String, orderSubTotalCents: Int, currency: String, mode: Mode) {
+        myExecutor.execute {
+            val input = JSONObject()
+            input.put("id", orderId)
+            input.put("shopAppId", appId)
+            val subTotal = JSONObject()
+            subTotal.put("cents", orderSubTotalCents)
+            subTotal.put("currency", currency)
+            input.put("subtotal", subTotal)
+            val param = JSONObject()
+            param.put(
+                "query",
+                """
+                mutation CreateOptedOutOrder {
+                  createOptedOutOrder(input: "$input") {
+                    created
+                    error
+                  }
+                }
+            """
+            )
+
+            val response = AirRobeApiService.requestPOST(
+                if (mode == Mode.PRODUCTION)
+                    AirRobeConstants.AIRROBE_CONNECTOR_PRODUCTION + "/graphql"
+                else
+                    AirRobeConstants.AIRROBE_CONNECTOR_SANDBOX + "/graphql",
+                param
+            )
+
+            myHandler.post {
+                if (response != null) {
+                    val obj = JSONObject(response)
+                    parseToModel(obj)
+                } else {
+                    airRobeCreateOptedOutOrderListener?.onFailedCreateOptedOutOrderApi()
+                }
+            }
+        }
+    }
+
+    private fun parseToModel(jsonObject: JSONObject) {
+        try {
+            val data = jsonObject.getJSONObject("data")
+            val createOptedOutOrder = data.getJSONObject("createOptedOutOrder")
+            val created = createOptedOutOrder.getBoolean("created")
+            val error = createOptedOutOrder.getString("error")
+            val dataModel = AirRobeCreateOptedOutOrderModel(
+                AirRobeCreateOptedOutOrderDataModel(
+                    AirRobeCreateOptedOutOrderSubModel(
+                        created, error
+                    )
+                )
+            )
+            airRobeCreateOptedOutOrderListener?.onSuccessCreateOptedOutOrderApi(dataModel)
+        } catch (exception: JSONException) {
+            airRobeCreateOptedOutOrderListener?.onFailedCreateOptedOutOrderApi("Create Opted Out Order JSON parse issue: " + exception.localizedMessage)
+        }
+    }
+}

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeCreateOptedOutOrderController.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeCreateOptedOutOrderController.kt
@@ -16,7 +16,7 @@ internal class AirRobeCreateOptedOutOrderController {
     private val myHandler = Handler(Looper.getMainLooper())
     var airRobeCreateOptedOutOrderListener: AirRobeCreateOptedOutOrderListener? = null
 
-    fun start(orderId: String, appId: String, orderSubTotalCents: Int, currency: String, mode: Mode) {
+    fun start(orderId: String, appId: String, orderSubtotalCents: Int, currency: String, mode: Mode) {
         myExecutor.execute {
             val param = JSONObject()
             param.put(
@@ -36,7 +36,7 @@ internal class AirRobeCreateOptedOutOrderController {
             inputData.put("shopAppId", appId)
 
             val subTotal = JSONObject()
-            subTotal.put("cents", orderSubTotalCents)
+            subTotal.put("cents", orderSubtotalCents)
             subTotal.put("currency", currency)
             inputData.put("subtotal", subTotal)
 

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/listeners/AirRobeCreateOptedOutOrderListener.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/listeners/AirRobeCreateOptedOutOrderListener.kt
@@ -1,0 +1,8 @@
+package com.airrobe.widgetsdk.airrobewidget.service.listeners
+
+import com.airrobe.widgetsdk.airrobewidget.service.models.AirRobeCreateOptedOutOrderModel
+
+internal interface AirRobeCreateOptedOutOrderListener {
+    fun onSuccessCreateOptedOutOrderApi(data: AirRobeCreateOptedOutOrderModel)
+    fun onFailedCreateOptedOutOrderApi(error: String? = null)
+}

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeCreateOptedOutOrderModel.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeCreateOptedOutOrderModel.kt
@@ -1,0 +1,14 @@
+package com.airrobe.widgetsdk.airrobewidget.service.models
+
+internal data class AirRobeCreateOptedOutOrderModel (
+    var data: AirRobeCreateOptedOutOrderDataModel
+)
+
+internal data class AirRobeCreateOptedOutOrderDataModel(
+    var createOptedOutOrder: AirRobeCreateOptedOutOrderSubModel
+)
+
+internal data class AirRobeCreateOptedOutOrderSubModel(
+    var created: Boolean,
+    var error: String
+)

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeCreateOptedOutOrderModel.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/models/AirRobeCreateOptedOutOrderModel.kt
@@ -10,5 +10,5 @@ internal data class AirRobeCreateOptedOutOrderDataModel(
 
 internal data class AirRobeCreateOptedOutOrderSubModel(
     var created: Boolean,
-    var error: String
+    var error: String?
 )

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeConfirmation.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeConfirmation.kt
@@ -41,7 +41,7 @@ class AirRobeConfirmation @JvmOverloads constructor(
 
     private var orderId: String? = null
     private var email: String? = null
-    private var orderSubTotalCents: Int = AirRobeConstants.INT_NULL_MAGIC_VALUE
+    private var orderSubtotalCents: Int = AirRobeConstants.INT_NULL_MAGIC_VALUE
     private var currency: String = "AUD"
     private var fraudRisk: Boolean = false
 
@@ -188,13 +188,13 @@ class AirRobeConfirmation @JvmOverloads constructor(
     fun initialize(
         orderId: String,
         email: String,
-        orderSubTotalCents: Int = AirRobeConstants.INT_NULL_MAGIC_VALUE,
+        orderSubtotalCents: Int = AirRobeConstants.INT_NULL_MAGIC_VALUE,
         currency: String = "AUD",
         fraudRisk: Boolean = false
     ) {
         this.orderId = orderId
         this.email = email
-        this.orderSubTotalCents = orderSubTotalCents
+        this.orderSubtotalCents = orderSubtotalCents
         this.currency = currency
         this.fraudRisk = fraudRisk
         initializeConfirmationWidget()
@@ -244,15 +244,15 @@ class AirRobeConfirmation @JvmOverloads constructor(
     }
 
     private fun createOptedOutOrder() {
-        if (orderId.isNullOrEmpty() || orderSubTotalCents == AirRobeConstants.INT_NULL_MAGIC_VALUE) {
-            Log.e(TAG, "Not able to call CreateOptedOutOrder because orderId or orderSubTotalCents is not passed.")
+        if (orderId.isNullOrEmpty() || orderSubtotalCents == AirRobeConstants.INT_NULL_MAGIC_VALUE) {
+            Log.e(TAG, "Not able to call CreateOptedOutOrder because orderId or orderSubtotalCents is not passed.")
             return
         }
         val createOptedOutOrderController = AirRobeCreateOptedOutOrderController()
         createOptedOutOrderController.start(
             orderId!!,
             widgetInstance.configuration!!.appId,
-            orderSubTotalCents,
+            orderSubtotalCents,
             currency,
             widgetInstance.configuration!!.mode
         )

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeConfirmation.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeConfirmation.kt
@@ -16,6 +16,7 @@ import com.airrobe.widgetsdk.airrobewidget.config.*
 import com.airrobe.widgetsdk.airrobewidget.config.AirRobeConstants
 import com.airrobe.widgetsdk.airrobewidget.config.AirRobeWidgetConfig
 import com.airrobe.widgetsdk.airrobewidget.config.AirRobeWidgetInstance
+import com.airrobe.widgetsdk.airrobewidget.service.api_controllers.AirRobeCreateOptedOutOrderController
 import com.airrobe.widgetsdk.airrobewidget.service.api_controllers.AirRobeEmailCheckController
 import com.airrobe.widgetsdk.airrobewidget.service.api_controllers.AirRobeIdentifyOrderController
 import com.airrobe.widgetsdk.airrobewidget.service.listeners.AirRobeEmailCheckListener
@@ -40,6 +41,8 @@ class AirRobeConfirmation @JvmOverloads constructor(
 
     private var orderId: String? = null
     private var email: String? = null
+    private var orderSubTotalCents: Int = AirRobeConstants.INT_NULL_MAGIC_VALUE
+    private var currency: String = "AUD"
     private var fraudRisk: Boolean = false
 
     var widgetBackgroundColor: Int =
@@ -185,10 +188,14 @@ class AirRobeConfirmation @JvmOverloads constructor(
     fun initialize(
         orderId: String,
         email: String,
+        orderSubTotalCents: Int = AirRobeConstants.INT_NULL_MAGIC_VALUE,
+        currency: String = "AUD",
         fraudRisk: Boolean = false
     ) {
         this.orderId = orderId
         this.email = email
+        this.orderSubTotalCents = orderSubTotalCents
+        this.currency = currency
         this.fraudRisk = fraudRisk
         initializeConfirmationWidget()
     }
@@ -221,6 +228,7 @@ class AirRobeConfirmation @JvmOverloads constructor(
             AirRobeAppUtils.dispatchEvent(context, EventName.ConfirmationRender.raw, PageName.ThankYou.raw)
         } else {
             visibility = GONE
+            createOptedOutOrder()
             Log.e(TAG, "Confirmation widget is not eligible to show up")
         }
     }
@@ -232,6 +240,21 @@ class AirRobeConfirmation @JvmOverloads constructor(
             config,
             orderId,
             AirRobeSharedPreferenceManager.getOrderOptedIn(context)
+        )
+    }
+
+    private fun createOptedOutOrder() {
+        if (orderId.isNullOrEmpty() || orderSubTotalCents == AirRobeConstants.INT_NULL_MAGIC_VALUE) {
+            Log.e(TAG, "Not able to call CreateOptedOutOrder because orderId or orderSubTotalCents is not passed.")
+            return
+        }
+        val createOptedOutOrderController = AirRobeCreateOptedOutOrderController()
+        createOptedOutOrderController.start(
+            orderId!!,
+            widgetInstance.configuration!!.appId,
+            orderSubTotalCents,
+            currency,
+            widgetInstance.configuration!!.mode
         )
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = '1.8.0'
-    ext.build_gradle = '7.2.1'
+    ext.build_gradle = '7.2.2'
     ext.kotlin_gradle_plugin_version = '1.7.0'
     ext.gradle_maven_publish_plugin = '0.19.0'
     ext.java = '11'

--- a/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/ConfirmationActivity.kt
+++ b/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/ConfirmationActivity.kt
@@ -21,7 +21,8 @@ class ConfirmationActivity : AppCompatActivity() {
         val email: String = intent.getStringExtra("email") ?: ""
         confirmationWidget.initialize(
             orderId = "123456",
-            email = email
+            email = email,
+            orderSubTotalCents = 10000
         )
 
         val ivBack = findViewById<ImageView>(R.id.iv_back)

--- a/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/ConfirmationActivity.kt
+++ b/demo/src/main/java/com/airrobe/widgetsdk/airrobedemo/activities/ConfirmationActivity.kt
@@ -22,7 +22,7 @@ class ConfirmationActivity : AppCompatActivity() {
         confirmationWidget.initialize(
             orderId = "123456",
             email = email,
-            orderSubTotalCents = 10000
+            orderSubtotalCents = 10000
         )
 
         val ivBack = findViewById<ImageView>(R.id.iv_back)


### PR DESCRIPTION
## What's updated / implemented
- added `orderSubTotalCents` and `currency` as extra params to the confirmation widget initialization

```kotlin
    fun initialize(
        orderId: String,
        email: String,
        orderSubTotalCents: Int = AirRobeConstants.INT_NULL_MAGIC_VALUE,
        currency: String = "AUD",
        fraudRisk: Boolean = false
    )
```
- createOrderOptedOut mutation Api endpoint implemented with passed params to the confirmation widget
- logic implemented when to call this mutation
```kotlin
if (!AirRobeSharedPreferenceManager.getOrderOptedIn(context) || fraudRisk)
if (!orderId.isNullOrEmpty() && orderSubTotalCents != AirRobeConstants.INT_NULL_MAGIC_VALUE)
```

### What to Test
- [ ] check whether API call gets logged properly to the database.
- [ ] check whether the logic is correct by changing the parameters of the confirmation initialization in all possible ways.

### Test Environment
- Open our demo project through Android Studio.
- Inside `../airrobedemo/ApplicationController.kt -> ApplicationController class -> onCreate()`, we have `initialize` function which has `appId` and `mode` as params.
- Inside `../airrobedemo/activities/ConfirmationActivity.kt -> ConfirmationActivity class -> onCreate()`, we have `confirmationWidget.initialize()` function which has several params.
- Change these params in many ways as we want and see if the build is working as expected.