### PR TITLE
Add data for pageview event for multi opt-in

### DIFF
--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeTelemetryEventController.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/service/api_controllers/AirRobeTelemetryEventController.kt
@@ -27,7 +27,8 @@ internal class AirRobeTelemetryEventController {
         brand: String? = null,
         material: String? = null,
         category: String? = null,
-        department: String? = null
+        department: String? = null,
+        itemCount: Int? = null
     ) {
         myExecutor.execute {
             val param = JSONObject()
@@ -44,6 +45,7 @@ internal class AirRobeTelemetryEventController {
             if (!material.isNullOrEmpty()) properties.put("material", material)
             if (!category.isNullOrEmpty()) properties.put("category", category)
             if (!department.isNullOrEmpty()) properties.put("department", department)
+            if (itemCount != null) properties.put("itemCount", itemCount)
             param.put("properties", properties)
 
             val response = AirRobeApiService.requestPOST(

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/utils/AirRobeAppUtils.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/utils/AirRobeAppUtils.kt
@@ -31,7 +31,8 @@ internal object AirRobeAppUtils {
         brand: String? = null,
         material: String? = null,
         category: String? = null,
-        department: String? = null
+        department: String? = null,
+        itemCount: Int? = null
     ) {
         if (widgetInstance.configuration == null) {
             return
@@ -45,7 +46,8 @@ internal object AirRobeAppUtils {
             brand,
             material,
             category,
-            department
+            department,
+            itemCount
         )
     }
 

--- a/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
+++ b/AirRobeWidget/src/main/kotlin/com/airrobe/widgetsdk/airrobewidget/widgets/AirRobeMultiOptIn.kt
@@ -310,7 +310,7 @@ class AirRobeMultiOptIn @JvmOverloads constructor(
             AirRobeSharedPreferenceManager.setOrderOptedIn(context, false)
             return
         }
-        AirRobeAppUtils.telemetryEvent(context, TelemetryEventName.PageView.raw, PageName.Cart.raw)
+        AirRobeAppUtils.telemetryEvent(context, TelemetryEventName.PageView.raw, PageName.Cart.raw, itemCount = items.size)
         AirRobeAppUtils.dispatchEvent(context, EventName.PageView.raw, PageName.Cart.raw)
         if (items.isEmpty()) {
             Log.e(TAG, "Required params can't be empty")


### PR DESCRIPTION
### Context
added item count to the telemetry event for the pageview event in the multi-optin widget.

### What's updated/implemented
- added item count to the telemetry event for the pageview event in multi optin widget

### Considerations
Need to test it through the connector if it is logged properly.

### Release type
- [ ] Patch
- [x] Minor
- [ ] Major

### Peer review
- [x] The feature/changes have been peer reviewed
- [ ] Automated test coverage and correctness have been peer reviewed
- [ ] The test plan has been peer reviewed